### PR TITLE
Migrate to `np.isin`

### DIFF
--- a/connectomics/segmentation/labels.py
+++ b/connectomics/segmentation/labels.py
@@ -156,7 +156,7 @@ def erode(labels: np.ndarray, radius: int = 2, min_size: int = 50):
     eroded = skimage.morphology.erosion(eroded, footprint=struct)
 
   # Preserve small components.
-  mask = np.in1d(labels.flat, small_segments).reshape(labels.shape)
+  mask = np.isin(labels.flat, small_segments).reshape(labels.shape)
   eroded[mask] = labels[mask]
   return eroded
 

--- a/connectomics/segmentation/labels_test.py
+++ b/connectomics/segmentation/labels_test.py
@@ -82,7 +82,7 @@ class UtilsTest(absltest.TestCase):
     eroded = labels.erode(seg, radius=3)
 
     # Ignore any objects that were completely removed during erosion.
-    large_enough = np.logical_not(np.in1d(seg.ravel(),
+    large_enough = np.logical_not(np.isin(seg.ravel(),
                                           np.unique(eroded))).reshape(seg.shape)
     expanded, _ = labels.watershed_expand(seg, voxel_size=(1, 1, 1))
     np.testing.assert_array_equal(expanded[large_enough], seg[large_enough])

--- a/connectomics/volume/mask.py
+++ b/connectomics/volume/mask.py
@@ -12,7 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Utilites for dealing with 2d and 3d object masks."""
+"""Utilities for dealing with 2d and 3d object masks."""
 
 import dataclasses
 import threading
@@ -200,7 +200,7 @@ def build_mask(
         if chan_config.expression:
           bool_mask = eval(chan_config.expression)  # pylint: disable=eval-used
         elif chan_config.values:
-          bool_mask = np.in1d(channel_mask, chan_config.values).reshape(
+          bool_mask = np.isin(channel_mask, chan_config.values).reshape(
               channel_mask.shape
           )
         else:


### PR DESCRIPTION
# PR Summary
This small PR migrates `np.in1d` to `np.isin` in order to resolve the deprecation warnings:
```python
DeprecationWarning: `in1d` is deprecated. Use `np.isin` instead.
```